### PR TITLE
Refine tag selection and vault display

### DIFF
--- a/tag-card.ts
+++ b/tag-card.ts
@@ -1,0 +1,410 @@
+import { app } from "../globals";
+import { customElement, state, query, property } from "lit/decorators.js";
+import { translate as $l } from "@padloc/locale/src/translate";
+import { StateMixin } from "../mixins/state";
+import { shared } from "../styles";
+import "./icon";
+import "./input";
+import "./button";
+import { css, html, LitElement } from "lit";
+
+interface TagCard {
+    name: string;
+    count: number;
+}
+
+@customElement("pl-tag-cards")
+export class TagCards extends StateMixin(LitElement) {
+    @state()
+    private _tagCards: TagCard[] = [];
+
+    @state()
+    private _filteredTagCards: TagCard[] = [];
+
+    @state()
+    private _filterShowing: boolean = false;
+
+    @state()
+    private _searchValue: string = "";
+
+    @property()
+    selectedTag: string | null = null;
+
+    @query("#filterInput")
+    private _filterInput: any;
+
+    async stateChanged() {
+        this._updateTagCards();
+    }
+
+    private _updateTagCards() {
+        const tagCounts = new Map<string, number>();
+        for (const vault of this.state.vaults) {
+            for (const item of vault.items) {
+                for (const tag of item.tags) {
+                    tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+                }
+            }
+        }
+        this._tagCards = Array.from(tagCounts.entries())
+            .map(([name, count]) => ({ name, count }))
+            .sort((a, b) => a.name.localeCompare(b.name));
+        this._filterTags();
+    }
+
+    private _onTagClick(tagName: string) {
+        this.dispatchEvent(new CustomEvent("tag-selected", { 
+            detail: { tag: tagName },
+            bubbles: true,
+            composed: true 
+        }));
+    }
+
+    async search(val?: string, focus = true) {
+        this._filterShowing = true;
+        await this.updateComplete;
+        setTimeout(() => {
+            if (val && val !== this._searchValue) {
+                this._searchValue = val;
+                if (this._filterInput) {
+                    this._filterInput.value = val;
+                }
+                this._filterTags();
+            } else if (this._filterInput) {
+                this._filterInput.value = this._searchValue;
+            }
+            if (focus && this._filterInput) {
+                this._filterInput.focus();
+            }
+        }, 100);
+    }
+
+    cancelSearch() {
+        this._searchValue = "";
+        this._filterShowing = false;
+        if (this._filterInput) {
+            this._filterInput.value = "";
+        }
+        this._filterTags();
+        if (this._filterInput) {
+            this._filterInput.blur();
+        }
+    }
+
+    private _filterTags() {
+        if (!this._searchValue.trim()) {
+            this._filteredTagCards = [...this._tagCards];
+        } else {
+            const term = this._searchValue.toLowerCase();
+            this._filteredTagCards = this._tagCards.filter(tag => 
+                tag.name.toLowerCase().includes(term)
+            );
+        }
+        this.requestUpdate();
+    }
+
+    private _updateItems() {
+        if (this._filterInput) {
+            this._searchValue = this._filterInput.value || "";
+            this._filterTags();
+        }
+    }
+
+    static styles = [
+        shared,
+        css`
+            :host {
+                display: flex;
+                flex-direction: column;
+                height: 100%;
+                background: var(--color-background);
+                overflow: hidden;
+            }
+
+            header {
+                overflow: visible;
+                --input-focus-color: transparent;
+            }
+
+            .header-icon {
+                height: 1.3em;
+            }
+
+            pl-input {
+                border: 1px solid var(--border-color);
+                border-radius: 4px;
+                background: var(--color-background);
+            }
+
+            pl-input:focus-within {
+                border-color: var(--color-highlight);
+            }
+
+            .content {
+                flex: 1;
+                padding: 1em;
+                overflow-y: auto;
+            }
+
+            .tags-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+                gap: 1em;
+                padding: 0.5em;
+            }
+
+            .tag-card {
+                background: var(--color-background);
+                border: 1px solid var(--border-color);
+                border-radius: 8px;
+                padding: 1em;
+                cursor: pointer;
+                transition: all 0.2s ease;
+                display: flex;
+                align-items: center;
+                gap: 0.5em;
+            }
+            
+            .tag-card.selected {
+                background: var(--color-highlight);
+                color: var(--color-background);
+                border-color: var(--color-highlight);
+            }
+
+            .tag-card:hover {
+                background: var(--color-shade-1);
+                border-color: var(--color-highlight);
+                transform: translateY(-2px);
+                box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+            }
+
+            .tag-icon {
+                color: var(--color-highlight);
+                font-size: 1.2em;
+            }
+            .tag-card.selected .tag-icon {
+                color: var(--color-background);
+            }
+
+            .tag-info {
+                flex: 1;
+                min-width: 0;
+            }
+
+            .tag-name {
+                font-weight: 500;
+                color: var(--color-foreground);
+                margin-bottom: 0.25em;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+            .tag-card.selected .tag-name {
+                color: var(--color-background);
+            }
+
+            .tag-count {
+                font-size: 0.9em;
+                color: var(--color-shade-2);
+            }
+            .tag-card.selected .tag-count {
+                color: var(--color-background);
+            }
+
+            .no-tags {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                height: 100%;
+                color: var(--color-shade-2);
+                text-align: center;
+                padding: 2em;
+            }
+
+            .no-tags-icon {
+                font-size: 4em;
+                margin-bottom: 1em;
+                opacity: 0.5;
+            }
+
+            .no-tags-text {
+                font-size: 1.1em;
+                margin-bottom: 0.5em;
+            }
+
+            .no-tags-subtext {
+                font-size: 0.9em;
+                opacity: 0.7;
+            }
+
+            .no-results {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                height: 100%;
+                color: var(--color-shade-2);
+                text-align: center;
+                padding: 2em;
+            }
+
+            .no-results-icon {
+                font-size: 4em;
+                margin-bottom: 1em;
+                opacity: 0.5;
+            }
+
+            .no-results-text {
+                font-size: 1.1em;
+                margin-bottom: 0.5em;
+            }
+
+            .no-results-subtext {
+                font-size: 0.9em;
+                opacity: 0.7;
+            }
+
+            .lighten {
+                color: var(--watermark-text-color) !important;
+            }
+
+            .icon-size {
+                font-size: 500% !important;
+            }
+        `,
+    ];
+
+    render() {
+        const hasTags = this._tagCards.length > 0;
+        const hasFilteredTags = this._filteredTagCards.length > 0;
+        const isSearching = this._filterShowing && this._searchValue.trim();
+
+        if (!hasTags) {
+            return html`
+                <header
+                    class="padded spacing horizontal center-aligning layout"
+                    ?hidden=${this._filterShowing}
+                >
+                    <pl-button
+                        class="transparent skinny stretch menu-button header-title"
+                        @click=${() =>
+                            this.dispatchEvent(new CustomEvent("toggle-menu", { composed: true, bubbles: true }))}
+                    >
+                        <div
+                            class="half-margined fill-horizontally horizontal spacing center-aligning layout text-left-aligning"
+                        >
+                            <pl-icon icon="tags-${app.effectiveTheme}"></pl-icon>
+                            <div class="stretch collapse ellipsis">${$l("Tags")}</div>
+                        </div>
+                    </pl-button>
+
+                    <div class="horizontal layout">
+                        <pl-button class="slim transparent" @click=${() => this.search()}>
+                            <pl-icon icon="search"></pl-icon>
+                        </pl-button>
+                    </div>
+                </header>
+
+                <header
+                    class="padded horizontal center-aligning layout"
+                    ?hidden=${!this._filterShowing}
+                >
+                    <pl-input
+                        class="slim stretch transparent"
+                        .placeholder=${$l("Type To Search")}
+                        id="filterInput"
+                        select-on-focus
+                        @input=${this._updateItems}
+                        @escape=${this.cancelSearch}
+                    >
+                        <pl-icon slot="before" class="left-margined left-padded subtle small" icon="search"></pl-icon>
+
+                        <pl-button slot="after" class="slim transparent" @click=${() => this.cancelSearch()}>
+                            <pl-icon icon="cancel"></pl-icon>
+                        </pl-button>
+                    </pl-input>
+                </header>
+
+                <div class="no-tags">
+                    <pl-icon icon="tags-${app.effectiveTheme}" class="no-tags-icon"></pl-icon>
+                    <div class="no-tags-text">${$l("No Tags Available")}</div>
+                    <div class="no-tags-subtext">${$l("Create some items with tags to see them here")}</div>
+                </div>
+            `;
+        }
+
+        return html`
+            <header
+                class="padded spacing horizontal center-aligning layout"
+                ?hidden=${this._filterShowing}
+            >
+                <pl-button
+                    class="transparent skinny stretch menu-button header-title"
+                    @click=${() =>
+                        this.dispatchEvent(new CustomEvent("toggle-menu", { composed: true, bubbles: true }))}
+                >
+                    <div
+                        class="half-margined fill-horizontally horizontal spacing center-aligning layout text-left-aligning"
+                    >
+                        <pl-icon icon="tags-${app.effectiveTheme}"></pl-icon>
+                        <div class="stretch collapse ellipsis">${$l("Tags")}</div>
+                    </div>
+                </pl-button>
+
+                <div class="horizontal layout">
+                    <pl-button class="slim transparent" @click=${() => this.search()}>
+                        <pl-icon icon="search"></pl-icon>
+                    </pl-button>
+                </div>
+            </header>
+
+            <header
+                class="padded horizontal center-aligning layout"
+                ?hidden=${!this._filterShowing}
+            >
+                <pl-input
+                    class="slim stretch transparent"
+                    .placeholder=${$l("Type To Search")}
+                    id="filterInput"
+                    select-on-focus
+                    @input=${this._updateItems}
+                    @escape=${this.cancelSearch}
+                >
+                    <pl-icon slot="before" class="left-margined left-padded subtle small" icon="search"></pl-icon>
+
+                    <pl-button slot="after" class="slim transparent" @click=${() => this.cancelSearch()}>
+                        <pl-icon icon="cancel"></pl-icon>
+                    </pl-button>
+                </pl-input>
+            </header>
+
+            ${isSearching && !hasFilteredTags
+                ? html`
+                    <div class="no-results">
+                        <pl-icon icon="search" class="no-results-icon"></pl-icon>
+                        <div class="no-results-text">${$l("Your search did not match any items.")}</div>
+                    </div>
+                `
+                : html`
+                    <div class="content">
+                        <div class="tags-grid">
+                            ${this._filteredTagCards.map(tag => html`
+                                <div 
+                                    class="tag-card ${this.selectedTag === tag.name ? 'selected' : ''}" 
+                                    @click=${() => this._onTagClick(tag.name)}
+                                >
+                                    <pl-icon icon="tag" class="tag-icon"></pl-icon>
+                                    <div class="tag-info">
+                                        <div class="tag-name">${tag.name}</div>
+                                        <div class="tag-count">${$l("{0} items", tag.count.toString())}</div>
+                                    </div>
+                                </div>
+                            `)}
+                        </div>
+                    </div>
+                `
+            }
+        `;
+    }
+}

--- a/tag-view.ts
+++ b/tag-view.ts
@@ -1,7 +1,6 @@
 import { View } from "./view";
 import { StateMixin } from "../mixins/state";
 import { Routing } from "../mixins/routing";
-import { ItemsList } from "./items-list";
 import "./item-view";
 import { customElement, query, state } from "lit/decorators.js";
 import { html, css } from "lit";
@@ -27,17 +26,14 @@ export class TagsView extends Routing(StateMixin(View)) {
     @state()
     private _selectedItemId: string | null = null;
 
-    @query("pl-items-list")
-    private _itemsList: ItemsList;
+
 
     async handleRoute([tagName, itemId]: [string, string]) {
         this._selectedTag = tagName || null;
         this._selectedItemId = itemId || null;
 
         if (this.active) {
-            if (this._selectedTag && !this._selectedItemId) {
-                this._itemsList?.cancelSearch();
-            }
+            // Handle route changes
         }
     }
 
@@ -46,14 +42,9 @@ export class TagsView extends Routing(StateMixin(View)) {
         router.go(`tags/${tag}`);
     }
 
-    private _onItemSelected(e: CustomEvent) {
-        const { itemId } = e.detail;
-        router.go(`tags/${this._selectedTag}/${itemId}`);
-    }
-
     private _getVaultsWithTag(tagName: string) {
         return this.state.vaults.filter(vault => 
-            vault.items.some(item => item.tags.includes(tagName))
+            vault.items.some((item: any) => item.tags.includes(tagName))
         );
     }
 
@@ -65,7 +56,7 @@ export class TagsView extends Routing(StateMixin(View)) {
     render() {
         const hasTagSelected = !!this._selectedTag;
         const hasItemSelected = !!this._selectedItemId;
-        const vaultsWithTag = hasTagSelected ? this._getVaultsWithTag(this._selectedTag!) : [];
+        const vaultsWithTag = hasTagSelected && this._selectedTag ? this._getVaultsWithTag(this._selectedTag) : [];
             
         return html`
             <div class="fullbleed pane layout ${hasItemSelected ? "open" : ""}">
@@ -101,7 +92,7 @@ export class TagsView extends Routing(StateMixin(View)) {
                                                         <div class="vault-name">${vault.name}</div>
                                                         <div class="vault-count">
                                                             ${$l("{0} items with this tag", 
-                                                                vault.items.filter(item => item.tags.includes(this._selectedTag!)).length.toString()
+                                                                vault.items.filter((item: any) => item.tags.includes(this._selectedTag!)).length.toString()
                                                             )}
                                                         </div>
                                                     </div>

--- a/tag-view.ts
+++ b/tag-view.ts
@@ -1,0 +1,275 @@
+import { View } from "./view";
+import { StateMixin } from "../mixins/state";
+import { Routing } from "../mixins/routing";
+import { ItemsList } from "./items-list";
+import "./item-view";
+import { customElement, query, state } from "lit/decorators.js";
+import { html, css } from "lit";
+import { router } from "../globals";
+import { translate as $l } from "@padloc/locale/src/translate";
+import { app } from "../globals";
+import { shared } from "../styles";
+import "./icon";
+import "./button";
+import "./input";
+
+// Import your pl-tag-cards component here if not already imported
+import "./tag-card";
+
+@customElement("pl-tags-view")
+export class TagsView extends Routing(StateMixin(View)) {
+    // This route pattern will now capture both the selected tag and the selected item ID.
+    readonly routePattern = /^tags(?:\/([^\/]+)(?:\/([^\/]+))?)?/;
+
+    @state()
+    private _selectedTag: string | null = null;
+    
+    @state()
+    private _selectedItemId: string | null = null;
+
+    @query("pl-items-list")
+    private _itemsList: ItemsList;
+
+    async handleRoute([tagName, itemId]: [string, string]) {
+        this._selectedTag = tagName || null;
+        this._selectedItemId = itemId || null;
+
+        if (this.active) {
+            if (this._selectedTag && !this._selectedItemId) {
+                this._itemsList?.cancelSearch();
+            }
+        }
+    }
+
+    private _onTagSelected(e: CustomEvent) {
+        const { tag } = e.detail;
+        router.go(`tags/${tag}`);
+    }
+
+    private _onItemSelected(e: CustomEvent) {
+        const { itemId } = e.detail;
+        router.go(`tags/${this._selectedTag}/${itemId}`);
+    }
+
+    private _getVaultsWithTag(tagName: string) {
+        return this.state.vaults.filter(vault => 
+            vault.items.some(item => item.tags.includes(tagName))
+        );
+    }
+
+    private _onVaultClick(vaultId: string) {
+        // Navigate to the vault view or show vault details
+        router.go(`vaults/${vaultId}`);
+    }
+
+    render() {
+        const hasTagSelected = !!this._selectedTag;
+        const hasItemSelected = !!this._selectedItemId;
+        const vaultsWithTag = hasTagSelected ? this._getVaultsWithTag(this._selectedTag!) : [];
+            
+        return html`
+            <div class="fullbleed pane layout ${hasItemSelected ? "open" : ""}">
+                <pl-tag-cards
+                    class="menu"
+                    @tag-selected=${this._onTagSelected}
+                    .selectedTag=${this._selectedTag}
+                ></pl-tag-cards>
+
+                ${hasTagSelected 
+                    ? html`
+                        <div class="pane vaults-pane">
+                            <header class="padded spacing horizontal center-aligning layout">
+                                <div class="horizontal spacing center-aligning layout">
+                                    <pl-icon icon="vault-${app.effectiveTheme}"></pl-icon>
+                                    <div class="stretch collapse ellipsis">
+                                        ${$l("Vaults with tag '{0}'", this._selectedTag)}
+                                    </div>
+                                </div>
+                            </header>
+                            
+                            <div class="content">
+                                ${vaultsWithTag.length > 0 
+                                    ? html`
+                                        <div class="vaults-grid">
+                                            ${vaultsWithTag.map(vault => html`
+                                                <div 
+                                                    class="vault-card" 
+                                                    @click=${() => this._onVaultClick(vault.id)}
+                                                >
+                                                    <pl-icon icon="vault-${app.effectiveTheme}" class="vault-icon"></pl-icon>
+                                                    <div class="vault-info">
+                                                        <div class="vault-name">${vault.name}</div>
+                                                        <div class="vault-count">
+                                                            ${$l("{0} items with this tag", 
+                                                                vault.items.filter(item => item.tags.includes(this._selectedTag!)).length.toString()
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            `)}
+                                        </div>
+                                    `
+                                    : html`
+                                        <div class="no-vaults">
+                                            <pl-icon icon="vault-${app.effectiveTheme}" class="no-vaults-icon"></pl-icon>
+                                            <div class="no-vaults-text">${$l("No vaults found with this tag")}</div>
+                                        </div>
+                                    `
+                                }
+                            </div>
+                        </div>
+                    `
+                    : html`
+                        <div class="pane no-selection-pane">
+                            <div class="no-selection">
+                                <pl-icon icon="vault-${app.effectiveTheme}" class="no-selection-icon"></pl-icon>
+                                <div class="no-selection-text">${$l("No Tag Selected")}</div>
+                                <div class="no-selection-subtext">${$l("Select a tag to see vaults containing items with that tag")}</div>
+                            </div>
+                        </div>
+                    `
+                }
+
+                <pl-item-view
+                    class="stretch"
+                    .selected=${hasItemSelected ? this._selectedItemId : null}
+                    ?hidden=${!hasItemSelected}
+                ></pl-item-view>
+            </div>
+        `;
+    }
+
+    static styles = [
+        ...View.styles,
+        shared,
+        css`
+            .pane {
+                flex: 1;
+                border-right: solid 1px var(--border-color);
+            }
+            .layout {
+                display: flex;
+            }
+            .menu {
+                width: 30em;
+                border-right: solid 1px var(--border-color);
+            }
+            
+            .vaults-pane {
+                display: flex;
+                flex-direction: column;
+                background: var(--color-background);
+            }
+            
+            .content {
+                flex: 1;
+                padding: 1em;
+                overflow-y: auto;
+            }
+            
+            .vaults-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+                gap: 1em;
+                padding: 0.5em;
+            }
+            
+            .vault-card {
+                background: var(--color-background);
+                border: 1px solid var(--border-color);
+                border-radius: 8px;
+                padding: 1em;
+                cursor: pointer;
+                transition: all 0.2s ease;
+                display: flex;
+                align-items: center;
+                gap: 0.5em;
+            }
+            
+            .vault-card:hover {
+                background: var(--color-shade-1);
+                border-color: var(--color-highlight);
+                transform: translateY(-2px);
+                box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+            }
+            
+            .vault-icon {
+                color: var(--color-highlight);
+                font-size: 1.2em;
+            }
+            
+            .vault-info {
+                flex: 1;
+                min-width: 0;
+            }
+            
+            .vault-name {
+                font-weight: 500;
+                color: var(--color-foreground);
+                margin-bottom: 0.25em;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+            
+            .vault-count {
+                font-size: 0.9em;
+                color: var(--color-shade-2);
+            }
+            
+            .no-vaults {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                height: 100%;
+                color: var(--color-shade-2);
+                text-align: center;
+                padding: 2em;
+            }
+            
+            .no-vaults-icon {
+                font-size: 4em;
+                margin-bottom: 1em;
+                opacity: 0.5;
+            }
+            
+            .no-vaults-text {
+                font-size: 1.1em;
+                margin-bottom: 0.5em;
+            }
+            
+            .no-selection-pane {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+            }
+            
+            .no-selection {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                color: var(--color-shade-2);
+                text-align: center;
+                padding: 2em;
+            }
+            
+            .no-selection-icon {
+                font-size: 4em;
+                margin-bottom: 1em;
+                opacity: 0.5;
+            }
+            
+            .no-selection-text {
+                font-size: 1.1em;
+                margin-bottom: 0.5em;
+            }
+            
+            .no-selection-subtext {
+                font-size: 0.9em;
+                opacity: 0.7;
+            }
+        `,
+    ];
+}


### PR DESCRIPTION
Display vaults instead of items when a tag is selected in `pl-tags-view`.

This change fulfills the requirement to show vaults containing items with the selected tag in the second pane and a "no tag selected" state when no tag is active, improving the user experience for tag-based navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e7d7c55-04ab-4a0e-a354-cea60ab57eeb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e7d7c55-04ab-4a0e-a354-cea60ab57eeb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

